### PR TITLE
Update renovate_task_service.go

### DIFF
--- a/internal/service/renovate_task_service.go
+++ b/internal/service/renovate_task_service.go
@@ -83,14 +83,6 @@ func (t *TaskService) RunTask(runConfig RunTaskConfig) (*ecs.RunTaskOutput, erro
 					Name: aws.String("init"),
 					Environment: []types.KeyValuePair{
 						{
-							Name:  aws.String("GITHUB_APPLICATION_ID"),
-							Value: aws.String(runConfig.ApplicationID),
-						},
-						{
-							Name:  aws.String("GITHUB_APPLICATION_PRIVATE_PEM_AWS_SECRET"),
-							Value: aws.String(runConfig.PEMAWSSecret),
-						},
-						{
 							Name:  aws.String("GITHUB_INSTALLATION_ID"),
 							Value: aws.String(runConfig.InstallationID),
 						},


### PR DESCRIPTION
Remove two environment variables that can be set in the Task.